### PR TITLE
Use a different set of critical points in the parameter plane, and be more flexible with the type of the functions

### DIFF
--- a/src/MandelMakie/Dylan-Families.jl
+++ b/src/MandelMakie/Dylan-Families.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.38
+# v0.20.20
 
 using Markdown
 using InteractiveUtils
@@ -11,17 +11,8 @@ begin
     using Pkg
     Pkg.activate(@__DIR__)
 
-    # Includes the file with definitions and imports the relevant modules
-    include("./src/MandelMakie.jl")
-    using .MandelMakie
-
-    # The next lines are necessary because Pluto does not expose the exported variables of a local package. You can skip those lines if you are loading this package into the REPL or Jupyter notebook.
-    Viewer = MandelMakie.Viewer
-    Viewer3D = MandelMakie.Viewer3D
-    Julia3D = MandelMakie.Julia3D
-    Fatou3D = MandelMakie.Fatou3D
-    set_parameter! = MandelMakie.set_parameter!
-    get_attractors = MandelMakie.get_attractors
+    # Import the relevant module
+    using MandelMakie
 end
 
 # ╔═╡ 1ba72fef-d5c4-4da4-9c17-4ba0096bf968
@@ -55,7 +46,6 @@ v = Viewer((z,λ) -> z^2 + λ*z, crit=λ -> -λ/2, coloring_method=:convergence_
   ╠═╡ =#
 
 # ╔═╡ 781ae5e9-545e-4c6b-9285-86f01a91e8ff
-# ╠═╡ disabled = true
 #=╠═╡
 MandelMakie.get_attractors(v)
   ╠═╡ =#
@@ -77,7 +67,13 @@ p2(z, c) = (z^2 - c) / (z^2 - 1)
 # ╔═╡ 8848c897-3fb7-4a7d-aa5f-d6b34438decb
 # ╠═╡ disabled = true
 #=╠═╡
-v = Viewer(p2, mandel_center = -0.5, mandel_diameter = 6.0, julia_diameter = 6.0, coloring_method=:convergence_time)
+v = Viewer(
+	p2,
+	mandel_center = -0.5,
+	mandel_diameter = 6.0,
+	julia_diameter = 6.0,
+	coloring_method=:convergence_time
+)
   ╠═╡ =#
 
 # ╔═╡ ac6a0d56-8990-45a8-90e0-4b876024c1c1
@@ -173,6 +169,7 @@ per4crit(ρ) = (4ρ^2 - 2ρ) / (-1 + ρ + ρ^2)
 Viewer(
 	per4,
 	crit = per4crit,
+	c = 1.0im,
 	coloring_method=:convergence_time,
 	projective_metric=true
 )
@@ -184,21 +181,16 @@ Viewer(
 Viewer(
 	per4,
 	crit = per4crit,
+	c = 1.0im,
 	coloring_method=:mod_period,
 	projective_metric=true
 )
   ╠═╡ =#
 
-# ╔═╡ e3045f93-acd6-4ccd-9898-3765b980e7f0
-
-
 # ╔═╡ 9f9585b3-011c-4ae9-b5ce-069ecef3a23e
 md"""
 ## Census maps
 """
-
-# ╔═╡ 0ac919c3-7c22-48cc-9256-1600f3fc3d3f
-
 
 # ╔═╡ f9c1ce04-81de-4458-8bf1-8225956b1011
 f49(z) = z^2 * (z-1) / ((z - 2/3)^2 * (z + 1/3))
@@ -210,7 +202,7 @@ Viewer(f49, coloring_method=:convergence_time, c=2/3)
   ╠═╡ =#
 
 # ╔═╡ f966a1a4-8b1a-4f84-8452-50ac7b0024e9
-f51(z) = 4 / 27 * (z - 1)^3 / z
+f51(z, c) = 4 / 27 * (z - 1)^3 / z
 
 # ╔═╡ 22b75feb-5c5e-42a4-aecc-b2f5ef4a938b
 # ╠═╡ disabled = true
@@ -254,7 +246,7 @@ devaney21crit(λ) = (λ/2)^(1/3)
 # ╔═╡ 3c9b33d6-19a5-4cea-a787-cb143c9c82ee
 # ╠═╡ disabled = true
 #=╠═╡
-Viewer(devaney21, crit = devaney21crit, mandel_diameter=1.5,c=-16/27)
+Viewer(devaney21, crit = devaney21crit, mandel_diameter=1.5, c=-16/27)
   ╠═╡ =#
 
 # ╔═╡ 60c35275-4216-40c1-91f0-ae35d0e8b31a
@@ -311,9 +303,7 @@ MandelMakie.get_attractors(v)
 # ╠═bea223da-13a5-4662-9e1f-ed6b27cf6d54
 # ╠═2962904d-2c4d-4fe7-9c59-f735ab953bfa
 # ╠═43af11b5-9593-4950-b853-8fa8869e6ace
-# ╠═e3045f93-acd6-4ccd-9898-3765b980e7f0
-# ╠═9f9585b3-011c-4ae9-b5ce-069ecef3a23e
-# ╠═0ac919c3-7c22-48cc-9256-1600f3fc3d3f
+# ╟─9f9585b3-011c-4ae9-b5ce-069ecef3a23e
 # ╠═f9c1ce04-81de-4458-8bf1-8225956b1011
 # ╠═3bcf1908-b27b-4734-8315-08121ce1657b
 # ╠═f966a1a4-8b1a-4f84-8452-50ac7b0024e9
@@ -322,7 +312,7 @@ MandelMakie.get_attractors(v)
 # ╠═fb1f9c3a-ec39-4d6f-acb3-1ddfd56d614b
 # ╠═36714bb2-3622-47eb-a7b5-f4c99145bd59
 # ╠═1c99e13e-e034-4d55-91be-ec22f1125a3d
-# ╠═29c2e25e-77f0-4d9f-94b0-163f8e58c7f8
+# ╟─29c2e25e-77f0-4d9f-94b0-163f8e58c7f8
 # ╟─0e78c206-3a75-419c-80d6-5ef4a8af6dc4
 # ╠═6cecbde5-42bc-4d74-8f68-2b458912585a
 # ╠═1388f3fa-c79e-4e4e-9455-b789fdb51378

--- a/src/MandelMakie/Examples.jl
+++ b/src/MandelMakie/Examples.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.46
+# v0.20.20
 
 using Markdown
 using InteractiveUtils
@@ -12,18 +12,8 @@ begin
     Pkg.activate(Base.current_project())
     Pkg.instantiate()
 
-    # Includes the file with definitions and imports the relevant modules
-    include("./src/MandelMakie.jl")
-    using .MandelMakie
-
-    # The next lines are necessary because Pluto does not expose the exported variables of a local package. You can skip those lines if you are loading this package into the REPL or Jupyter notebook.
-    Viewer = MandelMakie.Viewer
-    Viewer3D = MandelMakie.Viewer3D
-    Julia3D = MandelMakie.Julia3D
-    Fatou3D = MandelMakie.Fatou3D
-    set_parameter! = MandelMakie.set_parameter!
-    get_parameter = MandelMakie.get_parameter
-    get_attractors = MandelMakie.get_attractors
+    # Imports the relevant module
+    using MandelMakie
 end
 
 # ╔═╡ 1ba72fef-d5c4-4da4-9c17-4ba0096bf968
@@ -50,7 +40,7 @@ Then, call `Viewer` or `Viewer3D` to open a window where you see the Mandelbrot 
 """
 
 # ╔═╡ 70f82c8f-5b1b-46c7-87b3-5fad91ba1094
-Viewer(f; crit = crit, mandel_diameter = 1.0)
+Viewer(f; crit = crit, mandel_center = -0.5)
 
 # ╔═╡ 048320b4-12f2-4e7f-b267-8b15ad2485e0
 # ╠═╡ disabled = true
@@ -104,13 +94,11 @@ The cells below need to be manually updated to reflect the last changes in the v
 """
 
 # ╔═╡ b42b3753-33ba-4e25-a01b-b316dbd86787
-# ╠═╡ disabled = true
 #=╠═╡
 get_parameter(viewer)
   ╠═╡ =#
 
 # ╔═╡ f1a18d08-d81f-4667-b87a-8d19989b201b
-# ╠═╡ disabled = true
 #=╠═╡
 get_attractors(viewer)
   ╠═╡ =#
@@ -220,7 +208,7 @@ julia = Julia3D(g, im)
 # ╠═ebbe4d7f-9ab0-47f2-85e4-c0de7cb141c0
 # ╠═9e104891-fcb5-48fd-93a7-b2889381d2a6
 # ╟─dc85ce65-38a8-4990-86f5-ed6894b96695
-# ╠═4a085b76-da75-11ee-2b50-07309082fb46
+# ╟─4a085b76-da75-11ee-2b50-07309082fb46
 # ╟─0bbfff4b-7ee9-47f5-b19d-c97494438d4d
 # ╠═6e3d25a8-08a5-4e4d-a26c-6fce6623cef9
 # ╠═cab73282-0e64-45eb-958b-92f03fb4c8ca

--- a/src/MandelMakie/src/Fatou3D.jl
+++ b/src/MandelMakie/src/Fatou3D.jl
@@ -124,7 +124,7 @@ function Fatou3D(f::Function, c::Number = 0.0im; show_critical_points = false)
         scene,
         fatou_mesh,
         color = fatou_vertex_colors,
-        shading = FastShading,
+        shading = true,
         inspectable = false,
     )
 

--- a/src/MandelMakie/src/MandelMakie.jl
+++ b/src/MandelMakie/src/MandelMakie.jl
@@ -9,6 +9,7 @@ module MandelMakie
 export Viewer,
     Viewer3D,
     Fatou3D,
+    Julia3D,
     Attractor,
     set_parameter!,
     critical_points,

--- a/src/MandelMakie/src/Viewer3D.jl
+++ b/src/MandelMakie/src/Viewer3D.jl
@@ -125,7 +125,7 @@ function View3D(figure, f_proj, c, state; is_mandel, mark)
         color = vertex_colors,
         colormap = :twilight,
         colorrange = (0.0, 1.0),
-        shading = FastShading,
+        shading = true,
         inspectable = false,
     )
 


### PR DESCRIPTION
I think it's convenient to be able to write:
```
MandelMakie.Viewer(
       (z, c) -> z^2+c;
       crit = (c) -> 0)
```

In my notes, I still have a few things written with tuples:
```
MandelMakie.Viewer(
                  (z, c) -> z^3+ c*z^2 + z;
                  crit = (c) -> (-1/3*c - 1/3*sqrt(c^2 - 3),-1/3*c + 1/3*sqrt(c^2 - 3)),
                  par_crit=(c) -> -1/3*c - sign(real(c))*1/3*sqrt(c^2 - 3),
                  mandel_diameter = 5)
```
The par_crit argument allows you to specify a different set of critical points when computing the connectedness locus. This might have a performance benefit, but I haven't confirmed that there is one.

Nothing here is significant, but it would be slightly more convenient for me if I could do this.